### PR TITLE
Use airbrakeapp.com instead of hoptoadapp.com and use https

### DIFF
--- a/notifier.js
+++ b/notifier.js
@@ -46,7 +46,7 @@
   
   window.onerror = (window.Airbrake = {}).notify = function(message, file, line) {
     if (apiKey) {
-      new Image().src = "http://hoptoadapp.com/notifier_api/v2/notices?data=" + escape(getXML(message, file, line));
+      new Image().src = "https://airbrakeapp.com/notifier_api/v2/notices?data=" + escape(getXML(message, file, line));
     }
   };
 })(this, location);


### PR DESCRIPTION
Thanks for your work. I'm using this library for a javascript only project. The Airbrake gem would indeed feel clumsy for this purpose.

I saw that you are still using the deprecated hoptoad domain. I changed this to the airbrake domain and used https instead of http. I'm not sure what minification script you are using so I left that as a TODO
