### PR TITLE
Without this fix, Airbrake rejects the notification

### DIFF
--- a/notifier.js
+++ b/notifier.js
@@ -27,7 +27,7 @@
               xmlNode("error",    undef,
                 xmlNode("class",      undef, "Error")    +
                 xmlNode("message",    undef, escapeText(message))    +
-                file && line && xmlNode("backtrace",  undef, '<line method="" file="' + escapeText(file) + '" number="' + escapeText(line) + '" />')
+                (file && line && xmlNode("backtrace",  undef, '<line method="" file="' + escapeText(file) + '" number="' + escapeText(line) + '" />'))
               ) +
               xmlNode("request",  undef,
                 xmlNode("component",  undef, "frontend")    +


### PR DESCRIPTION
because it does not include the error/class and error/message as per http://help.airbrake.io/kb/api-2/notifier-api-version-22

using && for conditional in the middle of string concatenation is a bad idea, but adding parens helps

```
'abc' + true && 'def' // 'def'
'abc' + (true && 'def') // 'abcdef'
```
